### PR TITLE
Forward argc/argv to Main()

### DIFF
--- a/examples/raylib-app-example.c
+++ b/examples/raylib-app-example.c
@@ -42,7 +42,7 @@ void Close(void* userData) {
     //--------------------------------------------------------------------------------------
 }
 
-App Main() {
+App Main(int argc, char* argv[]) {
     return (App) {
         .width = 800,
         .height = 450,

--- a/raylib-app.h
+++ b/raylib-app.h
@@ -142,7 +142,7 @@ typedef struct App {
  *
  * @return The App description for your Application.
  */
-extern App Main();
+extern App Main(int argc, char* argv[]);
 #endif
 
 #if defined(__cplusplus)
@@ -174,7 +174,7 @@ void RaylibAppWebUpdate(void* app) {
  */
 int main(int argc, char* argv[]) {
     // Get the user-defined App from their Main() function.
-    App app = Main();
+    App app = Main(argc, argv);
 
     // Config Flags
     if (app.configFlags != 0) {


### PR DESCRIPTION
Update `Main()` declaration and call site to accept `int argc, char* argv[]`, matching documented usage and giving users access to CLI args before `init` runs. Fixes #5