### PR TITLE
Add separate draw callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,30 +19,29 @@ bool Init(void** userData, int argc, char** argv) {
     return true;
 }
 
-bool UpdateDrawFrame(void* userData) {
-    BeginDrawing();
-
-        ClearBackground(RAYWHITE);
-
-        DrawText("Congrats! You created your first raylib-app!", 180, 200, 20, LIGHTGRAY);
-
-    EndDrawing();
-
+bool Update(void* userData) {
     // Return false to exit the application.
-    return true;
+    return !IsKeyDown(KEY_Q);
+}
+
+void Draw(void* userData) {
+    // BeginDrawing() and EndDrawing() are called automatically by raylib-app.
+    ClearBackground(RAYWHITE);
+    DrawText("Congrats! You created your first raylib-app!", 180, 200, 20, LIGHTGRAY);
 }
 
 void Close(void* userData) {
     // CloseWindow() is automatically called after this function completes.
 }
 
-App Main(int argc, char* argv[]) {
+App Main() {
     return (App) {
         .width = 800,
         .height = 450,
         .title = "raylib-app [core] example - basic window",
         .init = Init,
-        .update = UpdateDrawFrame,
+        .update = Update,
+        .draw = Draw,
         .close = Close,
         .fps = 60,
     };
@@ -51,22 +50,34 @@ App Main(int argc, char* argv[]) {
 
 ## API
 
-Rather than having your own `int main()`, you will define your own `App Main(int argc char* argv[])` function.
+Rather than having your own `int main()`, you will define your own `App Main()` function.
 
 ``` c
-App Main(int argc, char* argv[]) {
+App Main() {
     return (App) {
         .width = 800,                          // The width of the window
         .height = 450,                         // The height of the window
         .title = "raylib-app",                 // The window title
-        .init = Init,                          // The init callback that is called when the application initializes
-        .update = UpdateDrawFrame,             // The update callback that is called when the application should render
-        .close = Close,                        // The close callback which is called when the application is closed
+        .init = Init,                          // Called once after InitWindow(); receives argc/argv
+        .update = Update,                      // Called each frame; return false to exit
+        .draw = Draw,                          // Called each frame; BeginDrawing/EndDrawing are automatic
+        .close = Close,                        // Called before CloseWindow()
         .fps = 60,                             // The target frames-per-second
         .configFlags = FLAG_WINDOW_RESIZABLE   // The flags that are passed to SetConfigFlags()
     };
 }
 ```
+
+### Callbacks
+
+| Callback | Signature | Description |
+|----------|-----------|-------------|
+| `init`   | `bool (*init)(void** userData, int argc, char** argv)` | Called once after `InitWindow()`. Return `false` to abort. |
+| `update` | `bool (*update)(void* userData)` | Called each frame for logic. Return `false` to exit. |
+| `draw`   | `void (*draw)(void* userData)` | Called each frame for rendering. `BeginDrawing()`/`EndDrawing()` are called automatically. |
+| `close`  | `void (*close)(void* userData)` | Called before `CloseWindow()` for cleanup. |
+
+All callbacks are optional. `update` and `draw` can be used independently or together.
 
 ## Development
 

--- a/examples/raylib-app-example.c
+++ b/examples/raylib-app-example.c
@@ -40,7 +40,7 @@ void Close(void* userData) {
     //--------------------------------------------------------------------------------------
 }
 
-App Main(int argc, char* argv[]) {
+App Main() {
     return (App) {
         .width = 800,
         .height = 450,

--- a/examples/raylib-app-example.c
+++ b/examples/raylib-app-example.c
@@ -12,7 +12,7 @@ bool Init(void** userData, int argc, char** argv) {
     return true;
 }
 
-bool UpdateDrawFrame(void* userData) {
+bool Update(void* userData) {
     // Update
     //----------------------------------------------------------------------------------
     if (IsKeyDown(KEY_Q)) {
@@ -20,19 +20,17 @@ bool UpdateDrawFrame(void* userData) {
     }
     //----------------------------------------------------------------------------------
 
+    return true;
+}
+
+void Draw(void* userData) {
     // Draw
     //----------------------------------------------------------------------------------
-    BeginDrawing();
+    // BeginDrawing() and EndDrawing() are called automatically by raylib-app.
+    ClearBackground(RAYWHITE);
 
-        ClearBackground(RAYWHITE);
-
-        DrawText("Congrats! You created your first raylib-app!", 180, 200, 20, LIGHTGRAY);
-
-    EndDrawing();
+    DrawText("Congrats! You created your first raylib-app!", 180, 200, 20, LIGHTGRAY);
     //----------------------------------------------------------------------------------
-
-    // Return false to end the update loop.
-    return true;
 }
 
 void Close(void* userData) {
@@ -48,7 +46,8 @@ App Main(int argc, char* argv[]) {
         .height = 450,
         .title = "raylib-app [core] example - basic window",
         .init = Init,
-        .update = UpdateDrawFrame,
+        .update = Update,
+        .draw = Draw,
         .close = Close,
         .fps = 60,
     };

--- a/examples/raylib-app-example.c
+++ b/examples/raylib-app-example.c
@@ -42,7 +42,7 @@ void Close(void* userData) {
     //--------------------------------------------------------------------------------------
 }
 
-App Main() {
+App Main(int argc, char* argv[]) {
     return (App) {
         .width = 800,
         .height = 450,

--- a/raylib-app.h
+++ b/raylib-app.h
@@ -142,7 +142,7 @@ typedef struct App {
  *
  * @return The App description for your Application.
  */
-extern App Main();
+extern App Main(int argc, char* argv[]);
 #endif
 
 #if defined(__cplusplus)
@@ -174,7 +174,7 @@ void RaylibAppWebUpdate(void* app) {
  */
 int main(int argc, char* argv[]) {
     // Get the user-defined App from their Main() function.
-    App app = Main();
+    App app = Main(argc, argv);
 
     // Config Flags
     if (app.configFlags != 0) {

--- a/raylib-app.h
+++ b/raylib-app.h
@@ -52,13 +52,22 @@ typedef struct App {
     bool (*init)(void** userData, int argc, char** argv);
 
     /**
-     * The update callback to update and draw the application.
+     * The update callback for per-frame logic.
      *
      * @param userData The App information for the currently running application.
      *
      * @return True if the application is to continue running, false otherwise.
      */
     bool (*update)(void* userData);
+
+    /**
+     * The draw callback for rendering. Called each frame after update().
+     *
+     * BeginDrawing() and EndDrawing() are called by the wrapper around draw().
+     *
+     * @param userData The App information for the currently running application.
+     */
+    void (*draw)(void* userData);
 
     /**
      * The close callback used to deinitialize all application data.
@@ -165,6 +174,13 @@ void RaylibAppWebUpdate(void* app) {
             emscripten_cancel_main_loop();
         }
     }
+
+    // Call the draw function.
+    if (application->draw != NULL) {
+        BeginDrawing();
+        application->draw(application->userData);
+        EndDrawing();
+    }
 }
 #endif
 
@@ -206,14 +222,21 @@ int main(int argc, char* argv[]) {
     }
 
     // Start the update loop
-    if (app.update != NULL) {
+    if (app.update != NULL || app.draw != NULL) {
 #if defined(PLATFORM_WEB)
         emscripten_set_main_loop_arg(RaylibAppWebUpdate, &app, app.fps, 1);
 #else
         // Stop running if the Window or App have been told to close.
         while (!WindowShouldClose()) {
-            if (!app.update(app.userData)) {
-                break;
+            if (app.update != NULL) {
+                if (!app.update(app.userData)) {
+                    break;
+                }
+            }
+            if (app.draw != NULL) {
+                BeginDrawing();
+                app.draw(app.userData);
+                EndDrawing();
             }
         }
 #endif

--- a/raylib-app.h
+++ b/raylib-app.h
@@ -151,7 +151,7 @@ typedef struct App {
  *
  * @return The App description for your Application.
  */
-extern App Main(int argc, char* argv[]);
+extern App Main();
 #endif
 
 #if defined(__cplusplus)
@@ -190,7 +190,7 @@ void RaylibAppWebUpdate(void* app) {
  */
 int main(int argc, char* argv[]) {
     // Get the user-defined App from their Main() function.
-    App app = Main(argc, argv);
+    App app = Main();
 
     // Config Flags
     if (app.configFlags != 0) {


### PR DESCRIPTION
Adds an optional `draw` field to `App` for rendering; the wrapper calls `BeginDrawing()`/`EndDrawing()` around it automatically. The existing `update` callback remains for per-frame logic. Both are optional and backwards-compatible. Fixes #4