### PR TITLE
Fix K&R-style empty parameter list in Main()

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ void Close(void* userData) {
     // CloseWindow() is automatically called after this function completes.
 }
 
-App Main() {
+App Main(void) {
     return (App) {
         .width = 800,
         .height = 450,
@@ -50,10 +50,10 @@ App Main() {
 
 ## API
 
-Rather than having your own `int main()`, you will define your own `App Main()` function.
+Rather than having your own `int main()`, you will define your own `App Main(void)` function.
 
 ``` c
-App Main() {
+App Main(void) {
     return (App) {
         .width = 800,                          // The width of the window
         .height = 450,                         // The height of the window

--- a/examples/raylib-app-example.c
+++ b/examples/raylib-app-example.c
@@ -40,7 +40,7 @@ void Close(void* userData) {
     //--------------------------------------------------------------------------------------
 }
 
-App Main() {
+App Main(void) {
     return (App) {
         .width = 800,
         .height = 450,

--- a/raylib-app.h
+++ b/raylib-app.h
@@ -151,7 +151,7 @@ typedef struct App {
  *
  * @return The App description for your Application.
  */
-extern App Main();
+extern App Main(void);
 #endif
 
 #if defined(__cplusplus)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # raylib-app-test
 add_executable(raylib-app-test raylib-app-test.c)
-target_compile_options(raylib-app-test PRIVATE -Wall -Wextra -Wconversion -Wsign-conversion)
+target_compile_options(raylib-app-test PRIVATE -Wall -Wextra -Wconversion -Wsign-conversion -Wstrict-prototypes)
 target_link_libraries(raylib-app-test PUBLIC
     raylib
     raylib-app

--- a/test/raylib-app-test.c
+++ b/test/raylib-app-test.c
@@ -79,7 +79,7 @@ void Close(void* userData) {
     //--------------------------------------------------------------------------------------
 }
 
-App Main() {
+App Main(void) {
     // Create the application data.
     return (App) {
         .width = 640,


### PR DESCRIPTION
Changes `App Main()` to `App Main(void)` in header, examples, tests, and README, and adds `-Wstrict-prototypes` to the test target. Fixes #10