### PR TITLE
Fix web: call close() and CloseWindow() when update() returns false

### DIFF
--- a/raylib-app.h
+++ b/raylib-app.h
@@ -171,7 +171,12 @@ void RaylibAppWebUpdate(void* app) {
     // Call the update function.
     if (application->update != NULL) {
         if (!application->update(application->userData)) {
+            if (application->close != NULL) {
+                application->close(application->userData);
+            }
+            CloseWindow();
             emscripten_cancel_main_loop();
+            return;
         }
     }
 


### PR DESCRIPTION
Ensures the close callback and CloseWindow() are called on the web path when update() returns false, preventing resource leaks. Fixes #8