### PR TITLE
Fix web loop ignoring WindowShouldClose()

### DIFF
--- a/raylib-app.h
+++ b/raylib-app.h
@@ -173,6 +173,15 @@ void RaylibAppWebUpdate(void* app) {
         return;
     }
 
+    if (WindowShouldClose()) {
+        if (application->close != NULL) {
+            application->close(application->userData);
+        }
+        CloseWindow();
+        emscripten_cancel_main_loop();
+        return;
+    }
+
     // Call the update function.
     if (application->update != NULL) {
         if (!application->update(application->userData)) {


### PR DESCRIPTION
Check `WindowShouldClose()` at the start of `RaylibAppWebUpdate` so web and desktop paths behave consistently. Fixes #21