### PR TITLE
Add CMake install/export rules for find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,47 @@ project(raylib-app
     LANGUAGES C
 )
 
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
 # Register the cmake folder for find_package()
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # raylib-app
 add_library(raylib-app INTERFACE)
-target_include_directories(raylib-app INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+add_library(raylib-app::raylib-app ALIAS raylib-app)
+target_include_directories(raylib-app INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+# Install
+install(TARGETS raylib-app
+    EXPORT raylib-appTargets
+)
+install(FILES raylib-app.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(EXPORT raylib-appTargets
+    FILE raylib-appTargets.cmake
+    NAMESPACE raylib-app::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/raylib-app
+)
+configure_package_config_file(
+    cmake/raylib-appConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/raylib-appConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/raylib-app
+)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/raylib-appConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/raylib-appConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/raylib-appConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/raylib-app
+)
 
 # Options
 if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/cmake/raylib-appConfig.cmake.in
+++ b/cmake/raylib-appConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/raylib-appTargets.cmake")
+
+check_required_components(raylib-app)


### PR DESCRIPTION
Adds `install()` rules, a package config template, and a version file so downstream projects can use `find_package(raylib-app)` and link against `raylib-app::raylib-app`. Fixes #20