### PR TITLE
Fix stale @example reference in raylib-app.h

### DIFF
--- a/raylib-app.h
+++ b/raylib-app.h
@@ -152,7 +152,7 @@ typedef struct App {
  * The main entry point defining the application behavior.
  *
  * @see App
- * @example examples/core_basic_window.c
+ * @example examples/raylib-app-example.c
  *
  * @return The App description for your Application.
  */


### PR DESCRIPTION
Update the `@example` Doxygen tag from the non-existent `examples/core_basic_window.c` to the actual example file. Fixes #18